### PR TITLE
Make ViewMonitor class visible in Objective-C.

### DIFF
--- a/Source/ViewMonitor.swift
+++ b/Source/ViewMonitor.swift
@@ -6,7 +6,7 @@
 import UIKit
 import Foundation
 
-final public class ViewMonitor{
+final public class ViewMonitor:NSObject{
     
     static var sharedInstance = ViewMonitor()
     


### PR DESCRIPTION
As Apple [document](https://developer.apple.com/library/ios/documentation/Swift/Conceptual/BuildingCocoaApps/MixandMatch.html) said, swift classes are automatically show in Objective C as long they are declared within a class that inherits from an Objective-C class.
